### PR TITLE
Allow use of tcpdump-like BPF

### DIFF
--- a/local.bro
+++ b/local.bro
@@ -1,1 +1,2 @@
+@load base/frameworks/packet-filter
 @load conn-contents.bro


### PR DESCRIPTION
Add the bro config which enables the tcpdump-style filter options, which vortex also supports, to be added to the command-line